### PR TITLE
Fix for "Fatal error: load from misaligned raw pointer"

### DIFF
--- a/SwiftDump/SwiftDump.xcodeproj/project.pbxproj
+++ b/SwiftDump/SwiftDump.xcodeproj/project.pbxproj
@@ -380,7 +380,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/swift",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};
@@ -400,7 +400,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/swift",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};

--- a/SwiftDump/SwiftDump/MachO/Data+Extensions.swift
+++ b/SwiftDump/SwiftDump/MachO/Data+Extensions.swift
@@ -33,7 +33,7 @@ extension Data {
 	func extract<T>(_ type: T.Type, offset: Int = 0) -> T {
         let data = self[offset..<offset + MemoryLayout<T>.size];
         let ret = data.withUnsafeBytes { (ptr:UnsafeRawBufferPointer) -> T in
-            return ptr.load(as: T.self)
+            return ptr.loadUnaligned(as: T.self)
         }
         return ret;
 	}

--- a/SwiftDump/SwiftDump/Util/Ext.swift
+++ b/SwiftDump/SwiftDump/Util/Ext.swift
@@ -126,7 +126,7 @@ extension Data {
     
     func readValue<Type>(_ offset: Int) -> Type? {
         let val:Type? = self.withUnsafeBytes { (ptr:UnsafeRawBufferPointer) -> Type? in
-            return ptr.baseAddress?.advanced(by: offset).load(as: Type.self);
+            return ptr.baseAddress?.advanced(by: offset).loadUnaligned(as: Type.self);
         }
         return val;
     }


### PR DESCRIPTION
I built and ran this on the ` /Library/Developer/PrivateFrameworks/CoreDevice.framework/CoreDevice` library provided by the Xcode 15 beta. When I did, I got this error:

```
Swift/UnsafeRawPointer.swift:421: Fatal error: load from misaligned raw pointer
[1]    65670 trace trap  SwiftDump /Library/Developer/PrivateFrameworks/CoreDevice.framework/CoreDevic
```

I fixed this by changing uses of `UnsafeRawBufferPointer.load()` to `UnsafeRawBufferPointer.loadUnaligned()`.

I also updated the deployment target to 10.13, which is required by the current version of swift-argument-parser. The project now builds with Xcode 15 beta 4.